### PR TITLE
[travis-ci] Re-enable auto-deploy to gh-pages.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,14 @@ sudo: false
 branches:
     only:
     - master
+
+deploy:
+    local_dir: dist
+    email: bmeurer@chromium.org
+    name: Benedikt Meurer
+    project_name: web-tooling-benchmark
+    provider: pages
+    skip_cleanup: true
+    github_token: $GITHUB_TOKEN # Set in travis-ci.org dashboard
+    on:
+        branch: master


### PR DESCRIPTION
This reverts commit 5886cd83dfd6a89a82e6ed3ffff65836016c09b7,
which temporarily disabled the auto-deploy.