### PR TITLE
Fix the windows build.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "repository": "https://github.com/v8/web-tooling-benchmark",
   "main": "src/cli.js",
   "scripts": {
-    "build:uglify-es-bundled": "./node_modules/uglify-es/bin/uglifyjs -b preamble=\"'const UglifyJS = module.exports = {};'\" --self > ./build/uglify-es-bundled.js",
-    "build:uglify-js-bundled": "./node_modules/uglify-js/bin/uglifyjs -b preamble=\"'const UglifyJS = module.exports = {};'\" --self > ./build/uglify-js-bundled.js",
+    "build:uglify-es-bundled": "node node_modules/uglify-es/bin/uglifyjs -b preamble=\"'const UglifyJS = module.exports = {};'\" --self > build/uglify-es-bundled.js",
+    "build:uglify-js-bundled": "node node_modules/uglify-js/bin/uglifyjs -b preamble=\"'const UglifyJS = module.exports = {};'\" --self > build/uglify-js-bundled.js",
     "build": "webpack",
     "postinstall": "npm run build:uglify-es-bundled && npm run build:uglify-js-bundled && npm run build",
     "precommit": "lint-staged",


### PR DESCRIPTION
Windows doesn't pay attention to #! lines at the beginning of Node
scripts, so we need to invoke the node binary explicitly.