### PR TITLE
Clarify names of generated bundles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ node_js:
     - "8"
 script:
     - npm test
-    - node dist/run.js
+    - node dist/cli.js
 sudo: false
 branches:
     only:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ contributing, please read the
 
 ## Setup locally
 
-> The Web Tooling Benchmark doesn't officially support any version of [Node](https://www.nodejs.org) prior to Node 8, it currently works with Node 6 and Node 7, but that might change at any point in time.
+> The Web Tooling Benchmark doesn't officially support any version of [Node](https://www.nodejs.org/) prior to Node 8, it currently works with Node 6 and Node 7, but that might change at any point in time.
 
 To start developing on the Web Tooling Benchmark you only need to install its dependencies:
 
@@ -22,8 +22,8 @@ There's no formal test suite yet. For now the process is roughly:
 
 - [ ] Check that `npm install` passes.
 - [ ] Check that `npm test` passes.
-- [ ] Check that the suite runs in `node`, via `node src/cli`.
-- [ ] Check that the suite runs in `d8` via `/path/to/d8 dist/run.js`.
+- [ ] Check that the suite runs in `node`, via `node src/cli.js`.
+- [ ] Check that the suite runs in `d8` via `/path/to/d8 dist/cli.js`.
 - [ ] Check that the browser bundle works by pointing your browser to `dist/index.html`.
 
 ## Creating a new benchmark

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ $ npm install
 
 assuming that you have a working [Node](https://nodejs.org) installation. Once
 the command is done, it produces a bundled version that is suitable to run in
-JS shells (i.e. `d8`, `jsc` or `jsshell`) in `dist/run.js` and another bundle
-in `dist/bundle.js` that is used by the browser version in `dist/index.html`.
+JS shells (i.e. `d8`, `jsc` or `jsshell`) in `dist/cli.js` and another bundle
+in `dist/browser.js` that is used by the browser version in `dist/index.html`.
 
 ## Running
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,7 +12,7 @@ module.exports = [
     context: path.resolve("src"),
     entry: "./cli.js",
     output: {
-      filename: "run.js",
+      filename: "cli.js",
       path: path.resolve("dist")
     },
     bail: true,
@@ -38,7 +38,7 @@ module.exports = [
     context: path.resolve("src"),
     entry: "./bootstrap.js",
     output: {
-      filename: "bundle.js",
+      filename: "browser.js",
       path: path.resolve("dist")
     },
     bail: true,


### PR DESCRIPTION
`run.js` and `bundle.js` are not the most descriptive names. Let’s make it more clear which bundle is supposed to run where.

* `dist/run.js` → `dist/cli.js`
* `dist/bundle.js` → `dist/browser.js`