### PR TITLE
Remove confidence intervals from runners.

### DIFF
--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -103,11 +103,7 @@ suite.forEach(benchmark => {
     if (suite.aborted) return;
     displayResultMessage(
       benchmark.name,
-      `${benchmark.hz.toFixed(
-        2
-      )} <span class="interval">&plusmn; ${benchmark.stats.rme.toFixed(
-        2
-      )}%</span>`,
+      `${benchmark.hz.toFixed(2)}`,
       "result"
     );
     const iterations = benchmark.stats.sample.length;

--- a/src/cli.js
+++ b/src/cli.js
@@ -26,11 +26,7 @@ suite.on("cycle", event => {
   const hz = benchmark.hz;
   const stats = benchmark.stats;
   console.log(
-    `${align(name, 14, "right")}: ${align(
-      hz.toFixed(2),
-      5,
-      "right"
-    )} runs/sec ${align(`\xb1${stats.rme.toFixed(2)}%`, 7, "right")}`
+    `${align(name, 14, "right")}: ${align(hz.toFixed(2), 5, "right")} runs/sec`
   );
 });
 

--- a/src/style.css
+++ b/src/style.css
@@ -88,7 +88,7 @@ div#result-summary .score {
   color: rgb(19, 156, 7);
 }
 
-div#result-summary .score .interval {
+div#result-summary .score {
   display: block;
   font-size: 18px;
   line-height: 18px;
@@ -100,10 +100,6 @@ div#version {
   font-size: 12px;
   font-style: italic;
   color: darkgrey;
-}
-
-.interval {
-  opacity: 0.75;
 }
 
 a:link,


### PR DESCRIPTION
The confidence intervals we output at the moment are too imprecise to be useful, so it is better to remove them.