### PR TITLE
update babel to beta.32

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
   },
   "license": "BSD-3-Clause",
   "dependencies": {
+    "@babel/standalone": "7.0.0-beta.32",
     "acorn": "5.1.2",
-    "babel-standalone": "7.0.0-beta.3",
-    "babylon": "7.0.0-beta.30",
+    "babylon": "7.0.0-beta.32",
     "benchmark": "^2.1.4",
     "buble": "0.16.0",
     "chai": "4.1.2",

--- a/src/babel-benchmark.js
+++ b/src/babel-benchmark.js
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-const Babel = require("babel-standalone");
+const Babel = require("@babel/standalone");
 const babylon = require("babylon");
 const fs = require("fs");
 


### PR DESCRIPTION
aside: I think we should probably add a few more kinds of payloads

- should we have a test for es3/es5 so that would be base speed without actually running transforms but the startup time + printer?
- should switch to env instead of es2015
- es2017+?
- flow/jsx?
- ts?
