### PR TITLE
Use @babel/preset-env

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,10 @@
   },
   "license": "BSD-3-Clause",
   "dependencies": {
-    "@babel/standalone": "7.0.0-beta.32",
+    "@babel/core": "^7.0.0-beta.34",
+    "@babel/preset-env": "^7.0.0-beta.34",
     "acorn": "5.2.1",
-    "babylon": "7.0.0-beta.32",
+    "babylon": "7.0.0-beta.34",
     "benchmark": "^2.1.4",
     "buble": "0.17.3",
     "chai": "4.1.2",

--- a/src/babel-benchmark.js
+++ b/src/babel-benchmark.js
@@ -2,14 +2,27 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-const Babel = require("@babel/standalone");
+const Babel = require("@babel/core");
 const babylon = require("babylon");
 const fs = require("fs");
 
 const payloads = [
   {
     name: "vue.runtime.esm-nobuble-2.4.4.js",
-    options: { presets: ["es2015"], sourceType: "module" }
+    options: {
+      presets: [
+        [
+          "@babel/preset-env",
+          {
+            targets: {
+              browsers: ["last 2 versions"],
+              node: 4 // https://github.com/nodejs/Release#release-schedule
+            }
+          }
+        ]
+      ],
+      sourceType: "module"
+    }
   }
 ].map(({ name, options }) => {
   const code = fs.readFileSync(`third_party/${name}`, "utf8");


### PR DESCRIPTION
The yearly presets like preset-es2015 are deprecated, and the best practice is to use @babel/preset-env nowadays.

Ref. #27.