### PR TITLE
Feature: Ability to run individual benchmark

### DIFF
--- a/src/cli-flags-helper.js
+++ b/src/cli-flags-helper.js
@@ -17,7 +17,7 @@ const targetList = new Set([
   "uglify-js"
 ]);
 
-function getOnlyFlag(argv) {
+function getOnlyFlag() {
   const onlyIndex = process.argv.indexOf("--only");
   if (onlyIndex != -1) {
     return process.argv[onlyIndex + 1];

--- a/src/cli-flags-helper.js
+++ b/src/cli-flags-helper.js
@@ -1,0 +1,38 @@
+const targetList = new Set([
+  "acorn",
+  "babel",
+  "babylon",
+  "buble",
+  "chai",
+  "coffeescript",
+  "espree",
+  "esprima",
+  "jshint",
+  "lebab",
+  "prepack",
+  "prettier",
+  "source-map",
+  "typescript",
+  "uglify-es",
+  "uglify-js"
+]);
+
+function getOnlyFlag(argv) {
+  if (process.argv.indexOf("--only") != -1) {
+    return process.argv[process.argv.indexOf("--only") + 1];
+  }
+}
+
+module.exports = {
+  getTarget: function() {
+    let onlyArg = getOnlyFlag();
+    if (targetList.has(onlyArg)) {
+      return [onlyArg];
+    } else if (typeof ONLY != "undefined" && targetList.has(ONLY)) {
+      return [ONLY];
+    } else {
+      return [...targetList];
+    }
+  },
+  targetList: targetList
+};

--- a/src/cli-flags-helper.js
+++ b/src/cli-flags-helper.js
@@ -18,14 +18,15 @@ const targetList = new Set([
 ]);
 
 function getOnlyFlag(argv) {
-  if (process.argv.indexOf("--only") != -1) {
-    return process.argv[process.argv.indexOf("--only") + 1];
+  const onlyIndex = process.argv.indexOf("--only");
+  if (onlyIndex != -1) {
+    return process.argv[onlyIndex + 1];
   }
 }
 
 module.exports = {
-  getTarget: function() {
-    let onlyArg = getOnlyFlag();
+  getTarget: () => {
+    const onlyArg = getOnlyFlag();
     if (targetList.has(onlyArg)) {
       return [onlyArg];
     } else if (typeof ONLY != "undefined" && targetList.has(ONLY)) {

--- a/src/suite.js
+++ b/src/suite.js
@@ -14,26 +14,33 @@ const defaultOptions = {
   minSamples: 20
 };
 
-const suite = new Benchmark.Suite();
+const targetList = [
+  "acorn",
+  "babel",
+  "babylon",
+  "buble",
+  "chai",
+  "coffeescript",
+  "espree",
+  "esprima",
+  "jshint",
+  "lebab",
+  "prepack",
+  "prettier",
+  "source-map",
+  "typescript",
+  "uglify-es",
+  "uglify-js"
+];
 
-[
-  require("./acorn-benchmark"),
-  require("./babel-benchmark"),
-  require("./babylon-benchmark"),
-  require("./buble-benchmark"),
-  require("./chai-benchmark"),
-  require("./coffeescript-benchmark"),
-  require("./espree-benchmark"),
-  require("./esprima-benchmark"),
-  require("./jshint-benchmark"),
-  require("./lebab-benchmark"),
-  require("./prepack-benchmark"),
-  require("./prettier-benchmark"),
-  require("./source-map-benchmark"),
-  require("./typescript-benchmark"),
-  require("./uglify-es-benchmark"),
-  require("./uglify-js-benchmark")
-].forEach(options => {
+const suite = new Benchmark.Suite();
+const targetItems = ONLY ? [ONLY] : null;
+
+const requireList = (targetItems || targetList).map(val => {
+  return require(`./${val}-benchmark`);
+});
+
+requireList.forEach(options => {
   suite.add(Object.assign({}, options, defaultOptions));
 });
 

--- a/src/suite.js
+++ b/src/suite.js
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 const Benchmark = require("benchmark");
+const getTarget = require("./cli-flags-helper").getTarget;
 
 // We need to run deterministically, so we set 'maxTime' to 0, which
 // disables the variable iteration count feature of benchmark.js,
@@ -14,34 +15,12 @@ const defaultOptions = {
   minSamples: 20
 };
 
-const targetList = [
-  "acorn",
-  "babel",
-  "babylon",
-  "buble",
-  "chai",
-  "coffeescript",
-  "espree",
-  "esprima",
-  "jshint",
-  "lebab",
-  "prepack",
-  "prettier",
-  "source-map",
-  "typescript",
-  "uglify-es",
-  "uglify-js"
-];
-
 const suite = new Benchmark.Suite();
-const targetItems = ONLY ? [ONLY] : null;
 
-const requireList = (targetItems || targetList).map(val => {
-  return require(`./${val}-benchmark`);
-});
-
-requireList.forEach(options => {
-  suite.add(Object.assign({}, options, defaultOptions));
+getTarget().forEach(target => {
+  suite.add(
+    Object.assign({}, require(`./${target}-benchmark`), defaultOptions)
+  );
 });
 
 module.exports = suite;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,34 +6,10 @@ const CopyWebpackPlugin = require("copy-webpack-plugin");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const path = require("path");
 const webpack = require("webpack");
-
-const targetList = [
-  "acorn",
-  "babel",
-  "babylon",
-  "buble",
-  "chai",
-  "coffeescript",
-  "espree",
-  "esprima",
-  "jshint",
-  "lebab",
-  "prepack",
-  "prettier",
-  "source-map",
-  "typescript",
-  "uglify-es",
-  "uglify-js"
-];
+const targetList = require("./src/cli-flags-helper").targetList;
 
 function getTarget(env) {
-  return (
-    env &&
-    env.only &&
-    targetList.find(elem => {
-      return elem == env.only;
-    })
-  );
+  return env && targetList.has(env.only) && env.only;
 }
 
 module.exports = env => [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,36 @@ const HtmlWebpackPlugin = require("html-webpack-plugin");
 const path = require("path");
 const webpack = require("webpack");
 
-module.exports = [
+const targetList = [
+  "acorn",
+  "babel",
+  "babylon",
+  "buble",
+  "chai",
+  "coffeescript",
+  "espree",
+  "esprima",
+  "jshint",
+  "lebab",
+  "prepack",
+  "prettier",
+  "source-map",
+  "typescript",
+  "uglify-es",
+  "uglify-js"
+];
+
+function getTarget(env) {
+  return (
+    env &&
+    env.only &&
+    targetList.find(elem => {
+      return elem == env.only;
+    })
+  );
+}
+
+module.exports = env => [
   {
     context: path.resolve("src"),
     entry: "./cli.js",
@@ -31,6 +60,9 @@ module.exports = [
           "  console = {log: print};\n" +
           "}",
         raw: true
+      }),
+      new webpack.DefinePlugin({
+        ONLY: JSON.stringify(getTarget(env))
       })
     ]
   },
@@ -61,6 +93,9 @@ module.exports = [
       new HtmlWebpackPlugin({
         template: "./index.html",
         inject: "head"
+      }),
+      new webpack.DefinePlugin({
+        ONLY: JSON.stringify(getTarget(env))
       })
     ]
   }


### PR DESCRIPTION
Issue: https://github.com/v8/web-tooling-benchmark/issues/32

- Added `env.only` CLI flag to build individual benchmark
- Used Webpack [DefinePlugin](https://webpack.js.org/plugins/define-plugin/) to pass the only flag to `suite.js`
- To build: `npm run build -- --env.only babel` 
- To run via node: `node src/cli.js --only babel`

## TODO:

- [ ] Update README.md once changes are okay with everyone.