### PR TITLE
Move `uglify-es` and `uglify-js` to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,8 @@
     "source-map": "0.6.1",
     "string-align": "^0.2.0",
     "typescript": "2.7.2",
+    "uglify-es": "3.3.9",
+    "uglify-js": "3.3.16",
     "virtualfs": "^1.0.0"
   },
   "devDependencies": {
@@ -62,8 +64,6 @@
     "node-libs-browser": "^2.1.0",
     "os-browserify": "^0.3.0",
     "raw-loader": "github:bmeurer/raw-loader#escape",
-    "uglify-es": "3.1.9",
-    "uglify-js": "3.1.9",
     "webpack": "^3.8.1"
   }
 }


### PR DESCRIPTION
Update versions too.
Fixes https://github.com/v8/web-tooling-benchmark/issues/41