### PR TITLE
Add `SourceNode.fromStringWithSourceMap´ to `source-map` benchmark

### DIFF
--- a/src/source-map-benchmark.js
+++ b/src/source-map-benchmark.js
@@ -20,7 +20,12 @@ module.exports = {
       const smc = new sourceMap.SourceMapConsumer(payload);
       // ...then serialize the parsed source map to a String.
       const smg = sourceMap.SourceMapGenerator.fromSourceMap(smc);
-      return smg.toString();
+
+      // Create a SourceNode from generated code and a SourceMapConsumer
+      const fswsm = sourceMap.SourceNode.fromStringWithSourceMap(payload, smc);
+
+      // return smg.toString();
+      return [smg.toString(), fswsm.toString()];
     });
   }
 };

--- a/src/source-map-benchmark.js
+++ b/src/source-map-benchmark.js
@@ -21,10 +21,9 @@ module.exports = {
       // ...then serialize the parsed source map to a String.
       const smg = sourceMap.SourceMapGenerator.fromSourceMap(smc);
 
-      // Create a SourceNode from generated code and a SourceMapConsumer
+      // Create a SourceNode from the generated code and a SourceMapConsumer.
       const fswsm = sourceMap.SourceNode.fromStringWithSourceMap(payload, smc);
 
-      // return smg.toString();
       return [smg.toString(), fswsm.toString()];
     });
   }


### PR DESCRIPTION
Benchmark results without `SourceNode.fromStringWithSourceMap`:

![screenshot1](https://user-images.githubusercontent.com/15221596/37625720-5ae5d2dc-2bcd-11e8-9ae8-f47074a74ddd.png)

And with it:

![screenshot2](https://user-images.githubusercontent.com/15221596/37625732-62b1d7ea-2bcd-11e8-9007-53a1fdcefb95.png)

I'm not pretty sure that this is the correct way to it, so please, take a look! 😃 

Closes https://github.com/v8/web-tooling-benchmark/issues/19