### PR TITLE
Add a pre-commit hook to check benchmark dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build:uglify-js-bundled": "node node_modules/uglify-js/bin/uglifyjs -b preamble=\"'const UglifyJS = module.exports = {};'\" --self > build/uglify-js-bundled.js",
     "build": "webpack",
     "postinstall": "npm run build:uglify-es-bundled && npm run build:uglify-js-bundled && npm run build",
-    "precommit": "lint-staged",
+    "precommit": "node tools/hooks/pre-commit && lint-staged",
     "test": "jest",
     "benchmark": "node dist/cli.js"
   },
@@ -64,6 +64,7 @@
     "node-libs-browser": "^2.1.0",
     "os-browserify": "^0.3.0",
     "raw-loader": "github:bmeurer/raw-loader#escape",
+    "semver": "^5.5.0",
     "webpack": "^3.8.1"
   }
 }

--- a/tools/hooks/pre-commit.js
+++ b/tools/hooks/pre-commit.js
@@ -17,7 +17,7 @@ targetList.forEach(dependency => {
   }
 });
 
-if (invalid.length) {
+if (invalid.length > 0) {
   console.error(
     `ERROR: Benchmark dependencies must have explicit versions.${EOL}`
   );

--- a/tools/hooks/pre-commit.js
+++ b/tools/hooks/pre-commit.js
@@ -1,0 +1,30 @@
+// Check if benchmark dependencies have explicit versions
+const semver = require("semver");
+const { EOL } = require("os");
+
+const { dependencies } = require("../../package.json");
+const { targetList } = require("../../src/cli-flags-helper");
+
+// babel -> @babel/standalone
+targetList.delete("babel");
+targetList.add("@babel/standalone");
+
+const invalid = [];
+targetList.forEach(dependency => {
+  const version = dependencies[dependency];
+  if (!semver.valid(version)) {
+    invalid.push({ dependency, version });
+  }
+});
+
+if (invalid.length) {
+  console.error(
+    `ERROR: Benchmark dependencies must have explicit versions.${EOL}`
+  );
+  console.error(`Invalid dependencies:`);
+  invalid.forEach(({ dependency, version }) => {
+    console.error(`- ${dependency}: ${version}`);
+  });
+
+  process.exit(1);
+}

--- a/tools/hooks/pre-commit.js
+++ b/tools/hooks/pre-commit.js
@@ -9,13 +9,14 @@ const { targetList } = require("../../src/cli-flags-helper");
 targetList.delete("babel");
 targetList.add("@babel/standalone");
 
-const invalid = [];
-targetList.forEach(dependency => {
+const invalid = [...targetList].reduce((list, dependency) => {
   const version = dependencies[dependency];
   if (!semver.valid(version)) {
-    invalid.push({ dependency, version });
+    list.push({ dependency, version });
   }
-});
+  return list;
+}, []);
+
 
 if (invalid.length > 0) {
   console.error(


### PR DESCRIPTION
Related to https://github.com/v8/web-tooling-benchmark/issues/31#issuecomment-357596714

The hook checks that all the benchmark dependencies have an explicit version.

Output example:

![captura de pantalla 2018-03-20 a las 1 42 37](https://user-images.githubusercontent.com/15221596/37629608-06977b28-2be0-11e8-9ddf-ec8c0b4b07a2.png)

