### PR TITLE
Update virtualfs dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -942,7 +942,8 @@
     "base64-js": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
+      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
+      "dev": true
     },
     "bcrypt-pbkdf": {
       "version": "1.0.1",
@@ -975,10 +976,10 @@
       "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
       "dev": true
     },
-    "bitset.js": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bitset.js/-/bitset.js-4.1.0.tgz",
-      "integrity": "sha512-qy7NB0DY9XbTEZYhEVzEqMms52iR71kUnjacXfXK6Hobml/wVe5UX9uun+9HGqbsPhCZR8IZ8R+wjik7nUIHiQ=="
+    "bitset": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/bitset/-/bitset-5.0.3.tgz",
+      "integrity": "sha512-sUf+oh2tLafEOCliDSAsCYYj8m9ebq22Efw74eaP2AwV1JdWktrtFOt73unr/YoThFOYYANJhBvD7UZyYtUBsA=="
     },
     "bluebird": {
       "version": "3.5.1",
@@ -1151,15 +1152,6 @@
         "minimist": "1.2.0",
         "os-homedir": "1.0.2",
         "vlq": "1.0.0"
-      }
-    },
-    "buffer": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.1.0.tgz",
-      "integrity": "sha512-YkIRgwsZwJWTnyQrsBTWefizHh+8GYj3kbL1BTiAQ/9pwpino0G7B2gp5tx/FUBqUlvtxV85KNR3mwfAtv15Yw==",
-      "requires": {
-        "base64-js": "1.3.0",
-        "ieee754": "1.1.11"
       }
     },
     "buffer-from": {
@@ -2118,6 +2110,11 @@
           "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA="
         }
       }
+    },
+    "dom-walk": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
+      "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
     },
     "domain-browser": {
       "version": "1.2.0",
@@ -3848,6 +3845,14 @@
       "integrity": "sha512-TtY/sbOemiMKPRUDDanGCSgBYe7Mf0vbRsWnBZ+9yghpZ1MvcpSpuZFjHdEeY/LZjZy0vdLjS77L6HosisFiug==",
       "dev": true
     },
+    "get-random-values": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/get-random-values/-/get-random-values-1.2.0.tgz",
+      "integrity": "sha1-MpIO3oG+2YJl/0A3HPSSmb1YHvE=",
+      "requires": {
+        "global": "4.3.2"
+      }
+    },
     "get-stream": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
@@ -3932,6 +3937,22 @@
           "requires": {
             "is-extglob": "1.0.0"
           }
+        }
+      }
+    },
+    "global": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
+      "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
+      "requires": {
+        "min-document": "2.19.0",
+        "process": "0.5.2"
+      },
+      "dependencies": {
+        "process": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
+          "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
         }
       }
     },
@@ -4289,7 +4310,8 @@
     "ieee754": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.11.tgz",
-      "integrity": "sha512-VhDzCKN7K8ufStx/CLj5/PDTMgph+qwN5Pkd5i0sGnVwk56zJ0lkT8Qzi1xqWLS0Wp29DgDtNeS7v8/wMoZeHg=="
+      "integrity": "sha512-VhDzCKN7K8ufStx/CLj5/PDTMgph+qwN5Pkd5i0sGnVwk56zJ0lkT8Qzi1xqWLS0Wp29DgDtNeS7v8/wMoZeHg==",
+      "dev": true
     },
     "iferr": {
       "version": "0.1.5",
@@ -5803,6 +5825,14 @@
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
       "dev": true
     },
+    "min-document": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+      "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
+      "requires": {
+        "dom-walk": "0.1.1"
+      }
+    },
     "minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -6514,7 +6544,8 @@
     "path-browserify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
-      "integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo="
+      "integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=",
+      "dev": true
     },
     "path-dirname": {
       "version": "1.0.2",
@@ -6577,6 +6608,11 @@
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
+    },
+    "permaproxy": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/permaproxy/-/permaproxy-0.0.2.tgz",
+      "integrity": "sha1-HvRmli1dBhHVUJ4NjB29x6jA4Rs="
     },
     "pify": {
       "version": "3.0.0",
@@ -7200,11 +7236,12 @@
       "dev": true
     },
     "resource-counter": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/resource-counter/-/resource-counter-0.2.0.tgz",
-      "integrity": "sha1-i5jjPubCfd4mz1DdJ24wDJ4BV34=",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/resource-counter/-/resource-counter-1.2.4.tgz",
+      "integrity": "sha512-DGJChvE5r4smqPE+xYNv9r1u/I9cCfRR5yfm7D6EQckdKqMyVpJ5z0s40yn0EM0puFxHg6mPORrQLQdEbJ/RnQ==",
       "requires": {
-        "bitset.js": "4.1.0"
+        "babel-runtime": "6.26.0",
+        "bitset": "5.0.3"
       }
     },
     "restore-cursor": {
@@ -7597,6 +7634,22 @@
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true
+    },
+    "secure-random-bytes": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/secure-random-bytes/-/secure-random-bytes-1.0.1.tgz",
+      "integrity": "sha1-Df3kRtCKVRN/jkXCYt5M+TlsWtQ=",
+      "requires": {
+        "secure-random-octet": "1.0.2"
+      }
+    },
+    "secure-random-octet": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/secure-random-octet/-/secure-random-octet-1.0.2.tgz",
+      "integrity": "sha1-fIdC7l7CxODZJjvQdSjyMT7cG80=",
+      "requires": {
+        "get-random-values": "1.2.0"
+      }
     },
     "seedrandom": {
       "version": "2.4.3",
@@ -9045,16 +9098,16 @@
       }
     },
     "virtualfs": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/virtualfs/-/virtualfs-1.0.0.tgz",
-      "integrity": "sha1-859EnfUEjX/Nco0rq0CvEgvvbMM=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/virtualfs/-/virtualfs-2.1.0.tgz",
+      "integrity": "sha512-pAqWwW8UEb8+JsjaFTYiC3pZ539cXp44+L3I0c2TlkCzyk5Gal1VQbKP8yrjpOObTZtI++uQp8g0S7IYWtEZBg==",
       "requires": {
         "babel-runtime": "6.26.0",
-        "buffer": "5.1.0",
         "errno": "0.1.7",
-        "path-browserify": "0.0.0",
+        "permaproxy": "0.0.2",
         "readable-stream": "2.3.6",
-        "resource-counter": "0.2.0"
+        "resource-counter": "1.2.4",
+        "secure-random-bytes": "1.0.1"
       },
       "dependencies": {
         "isarray": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "typescript": "2.7.2",
     "uglify-es": "3.3.9",
     "uglify-js": "3.3.16",
-    "virtualfs": "^1.0.0"
+    "virtualfs": "^2.1.0"
   },
   "devDependencies": {
     "copy-webpack-plugin": "^4.2.0",


### PR DESCRIPTION
@CMCDragonkai When updating to virtualfs@2.0.4 as suggested in #53, the generated benchmark fails to run:

```
$ npm run benchmark

> web-tooling-benchmark@0.4.0 benchmark ~/projects/web-tooling-benchmark
> node dist/cli.js

~/projects/web-tooling-benchmark/dist/cli.js:175687
    Error.captureStackTrace(this, arguments.callee);
                                            ^

TypeError: 'caller', 'callee', and 'arguments' properties may not be accessed on strict mode functions or the arguments objects for calls to them
    at new CustomError (~/projects/web-tooling-benchmark/dist/cli.js:175687:45)
    at createError (~/projects/web-tooling-benchmark/dist/cli.js:175711:43)
    at ce (~/projects/web-tooling-benchmark/dist/cli.js:175717:12)
    at custom (~/projects/web-tooling-benchmark/dist/cli.js:175721:25)
    at ~/projects/web-tooling-benchmark/dist/cli.js:176038:25
    at createCommonjsModule (~/projects/web-tooling-benchmark/dist/cli.js:166043:35)
    at ~/projects/web-tooling-benchmark/dist/cli.js:175726:13
    at commonjsGlobal (~/projects/web-tooling-benchmark/dist/cli.js:166029:10)
    at Object.<anonymous> (~/projects/web-tooling-benchmark/dist/cli.js:166032:2)
    at Object.exports.byteLength (~/projects/web-tooling-benchmark/dist/cli.js:182197:30)
```

The offending line is part of `virtualfs/dist/index.browser.umd.js`. Would you be open to changing this to add strict mode support?
