### PR TITLE
add babel-minify to benchmarks suite

### DIFF
--- a/docs/in-depth.md
+++ b/docs/in-depth.md
@@ -38,6 +38,12 @@ Note that this explicitly excludes the [Babylon](https://github.com/babel/babylo
 and only measures the throughput of the actual transformations. The parser is tested
 separately by the `babylon` benchmark below.
 
+## babel-minify
+
+[Babel Minify](https://github.com/babel/minify) is an ES6+ aware minifier based on the Babel toolchain. It is written as a set of Babel plugins.
+
+This benchmark stresses the babel minifier on the (concatenated) JavaScript source for the ES2015 test in the [Speedometer](https://browserbench.org/Speedometer) 2.0 benchmark.
+
 ## babylon
 
 [Babylon](https://github.com/babel/babylon) is the frontend for the Babel transpiler and
@@ -198,9 +204,8 @@ compressor and beautifier toolkit, which is commonly used to minimize JavaScript
 bundles.
 
 This benchmark runs the UglifyJS minifier on the (concatenated) JavaScript source for
-the ES2015 test in the [Speedometer](https://browserbench.org/Speedometer) 2.0 benchmark.
+the ES2015 test in the [Lodash](https://lodash.com) module.
 
 ## uglify-es
 
-This benchmark stresses the new ES2015 and beyond minifier using the 196KiB
-ES2015 module containing the untranspiled [Vue](https://github.com/vuejs/vue) bundle.
+This benchmark stresses the new ES2015 and beyond minifier on the (concatenated) JavaScript source for the ES2015 test in the [Speedometer](https://browserbench.org/Speedometer) 2.0 benchmark.

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@babel/standalone": "7.0.0-beta.32",
     "acorn": "5.5.3",
     "autoprefixer": "8.2.0",
+    "babel-minify": "0.4.3",
     "babylon": "7.0.0-beta.32",
     "benchmark": "^2.1.4",
     "buble": "0.19.3",

--- a/src/babel-minify-benchmark.js
+++ b/src/babel-minify-benchmark.js
@@ -1,0 +1,21 @@
+const babelMinify = require("babel-minify");
+const fs = require("fs");
+
+const payloads = [
+  {
+    name: "speedometer-es2015-test-2.0.js",
+    options: {}
+  }
+].map(({ name, options }) => ({
+  payload: fs.readFileSync(`third_party/${name}`, "utf8"),
+  options
+}));
+
+module.exports = {
+  name: "babel-minify",
+  fn() {
+    return payloads.map(({ payload, options }) =>
+      babelMinify(payload, options)
+    );
+  }
+};

--- a/src/babel-minify-benchmarkt.test.js
+++ b/src/babel-minify-benchmarkt.test.js
@@ -1,0 +1,4 @@
+const babelMinifyBenchmark = require("./babel-minify-benchmark");
+
+it("babel-minify-benchmark runs to completion", () =>
+  void babelMinifyBenchmark.fn());

--- a/src/cli-flags-helper.js
+++ b/src/cli-flags-helper.js
@@ -1,6 +1,7 @@
 const targetList = new Set([
   "acorn",
   "babel",
+  "babel-minify",
   "babylon",
   "buble",
   "chai",


### PR DESCRIPTION
+ add babel-minify aka babili to the suite list.
+ fixed the uglify benchmark in the readme which was pointing to wrong file. 

Should i keep the license format at the top? 