### PR TITLE
Add `terser` benchmark and remove `uglify-es` benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,26 +49,26 @@ i.e. like this:
 $ node dist/cli.js
 Running Web Tooling Benchmark v0.5.1…
 -------------------------------------
-         acorn:  6.94 runs/s
-         babel:  7.45 runs/s
-  babel-minify:  6.66 runs/s
-       babylon:  6.26 runs/s
-         buble:  4.07 runs/s
-          chai: 14.33 runs/s
-  coffeescript:  5.95 runs/s
-        espree:  2.09 runs/s
-       esprima:  4.13 runs/s
-        jshint:  8.84 runs/s
-         lebab:  7.07 runs/s
-       postcss:  5.35 runs/s
-       prepack:  5.58 runs/s
-      prettier:  6.19 runs/s
-    source-map:  7.63 runs/s
-    typescript:  8.59 runs/s
-     uglify-es: 13.69 runs/s
-     uglify-js:  4.59 runs/s
+         acorn:  6.11 runs/s
+         babel:  5.59 runs/s
+  babel-minify:  6.79 runs/s
+       babylon:  5.48 runs/s
+         buble:  3.31 runs/s
+          chai: 10.49 runs/s
+  coffeescript:  4.72 runs/s
+        espree:  3.44 runs/s
+       esprima:  4.27 runs/s
+        jshint:  6.38 runs/s
+         lebab:  5.76 runs/s
+       postcss:  4.35 runs/s
+       prepack:  5.07 runs/s
+      prettier:  4.36 runs/s
+    source-map:  6.66 runs/s
+        terser: 10.87 runs/s
+    typescript:  6.62 runs/s
+     uglify-js:  3.48 runs/s
 -------------------------------------
-Geometric mean:  6.38 runs/s
+Geometric mean:  5.45 runs/s
 ```
 
 Or you open a web browser and point it to `dist/index.html`, or you can use one

--- a/docs/in-depth.md
+++ b/docs/in-depth.md
@@ -187,6 +187,12 @@ This benchmark stresses the source-map tool on both parsing and serializing a
 variety of different source maps, including the [Preact](http://preactjs.com)
 8.2.5 source map.
 
+## terser
+
+[terser](https://github.com/fabiosantoscode/terser) is a fork of `uglify-es` that retains API and CLI compatibility with `uglify-es` and `uglify-js@3`.
+
+This benchmark stresses the new ES2015 and beyond minifier on the (concatenated) JavaScript source for the ES2015 test in the [Speedometer](https://browserbench.org/Speedometer) 2.0 benchmark.
+
 ## typescript
 
 [TypeScript](https://github.com/Microsoft/TypeScript) is a language for
@@ -205,7 +211,3 @@ bundles.
 
 This benchmark runs the UglifyJS minifier on the (concatenated) JavaScript source for
 the ES2015 test in the [Lodash](https://lodash.com) module.
-
-## uglify-es
-
-This benchmark stresses the new ES2015 and beyond minifier on the (concatenated) JavaScript source for the ES2015 test in the [Speedometer](https://browserbench.org/Speedometer) 2.0 benchmark.

--- a/docs/in-depth.md
+++ b/docs/in-depth.md
@@ -191,7 +191,7 @@ variety of different source maps, including the [Preact](http://preactjs.com)
 
 [terser](https://github.com/fabiosantoscode/terser) is a fork of `uglify-es` that retains API and CLI compatibility with `uglify-es` and `uglify-js@3`.
 
-This benchmark stresses the new ES2015 and beyond minifier on the (concatenated) JavaScript source for the ES2015 test in the [Speedometer](https://browserbench.org/Speedometer) 2.0 benchmark.
+This benchmark stresses the new ES2015-and-beyond minifier on the (concatenated) JavaScript source for the ES2015 test in the [Speedometer](https://browserbench.org/Speedometer) 2.0 benchmark.
 
 ## typescript
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -907,7 +907,7 @@
     },
     "babel-helper-is-nodes-equiv": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-is-nodes-equiv/-/babel-helper-is-nodes-equiv-0.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/babel-helper-is-nodes-equiv/-/babel-helper-is-nodes-equiv-0.0.1.tgz",
       "integrity": "sha1-NOmzALFHnd2Y7HfqC76TQt/jloQ="
     },
     "babel-helper-is-void-0": {
@@ -1579,8 +1579,7 @@
     "buffer-from": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
-      "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA==",
-      "dev": true
+      "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA=="
     },
     "buffer-xor": {
       "version": "1.0.3",
@@ -8768,6 +8767,32 @@
       "integrity": "sha1-mTcqXJmb8t8WCvwNdL7U9HlIzSI=",
       "dev": true
     },
+    "terser": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-3.8.2.tgz",
+      "integrity": "sha512-FGSBXiBJe2TSXy6pWwXpY0YcEWEK35UKL64BBbxX3aHqM4Nj0RMqXvqBuoSGfyd80t8MKQ5JwYm5jRRGTSEFNg==",
+      "requires": {
+        "commander": "2.17.1",
+        "source-map": "0.6.1",
+        "source-map-support": "0.5.9"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.17.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+          "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
+        },
+        "source-map-support": {
+          "version": "0.5.9",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
+          "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
+          "requires": {
+            "buffer-from": "1.0.0",
+            "source-map": "0.6.1"
+          }
+        }
+      }
+    },
     "test-exclude": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.2.1.tgz",
@@ -9257,22 +9282,6 @@
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.2.tgz",
       "integrity": "sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw=="
-    },
-    "uglify-es": {
-      "version": "3.3.9",
-      "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
-      "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
-      "requires": {
-        "commander": "2.13.0",
-        "source-map": "0.6.1"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.13.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
-          "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA=="
-        }
-      }
     },
     "uglify-js": {
       "version": "3.3.16",

--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
   "main": "src/cli.js",
   "scripts": {
     "benchmark": "node dist/cli.js",
-    "build:uglify-es-bundled": "node node_modules/uglify-es/bin/uglifyjs -b preamble=\"'const UglifyJS = module.exports = {};'\" --self > build/uglify-es-bundled.js",
+    "build:terser-bundled": "node node_modules/terser/bin/uglifyjs -b preamble=\"'const Terser = module.exports = {};'\" --self > build/terser-bundled.js",
     "build:uglify-js-bundled": "node node_modules/uglify-js/bin/uglifyjs -b preamble=\"'const UglifyJS = module.exports = {};'\" --self > build/uglify-js-bundled.js",
     "build": "webpack",
-    "postinstall": "npm run build:uglify-es-bundled && npm run build:uglify-js-bundled && npm run build",
+    "postinstall": "npm run build:terser-bundled && npm run build:uglify-js-bundled && npm run build",
     "precommit": "node tools/hooks/pre-commit.js && lint-staged",
     "test": "jest",
     "update-lock": "npm install --package-lock"
@@ -59,8 +59,8 @@
     "prettier": "1.9.2",
     "source-map": "0.6.1",
     "string-align": "^0.2.0",
+    "terser": "3.8.2",
     "typescript": "2.7.2",
-    "uglify-es": "3.3.9",
     "uglify-js": "3.3.16",
     "virtualfs": "^2.1.0"
   },

--- a/src/cli-flags-helper.js
+++ b/src/cli-flags-helper.js
@@ -14,8 +14,8 @@ const targetList = new Set([
   "prepack",
   "prettier",
   "source-map",
+  "terser",
   "typescript",
-  "uglify-es",
   "uglify-js"
 ]);
 

--- a/src/terser-benchmark.js
+++ b/src/terser-benchmark.js
@@ -1,8 +1,8 @@
-// Copyright 2017 the V8 project authors. All rights reserved.
+// Copyright 2018 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-const UglifyJS = require("../build/uglify-es-bundled");
+const Terser = require("../build/terser-bundled");
 const fs = require("fs");
 
 const payloads = [
@@ -16,10 +16,10 @@ const payloads = [
 }));
 
 module.exports = {
-  name: "uglify-es",
+  name: "terser",
   fn() {
     return payloads.map(({ payload, options }) =>
-      UglifyJS.minify(payload, options)
+      Terser.minify(payload, options)
     );
   }
 };

--- a/src/terser-benchmark.test.js
+++ b/src/terser-benchmark.test.js
@@ -1,0 +1,7 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+const terserBenchmark = require("./terser-benchmark");
+
+it("terser-benchmark runs to completion", () => void terserBenchmark.fn());

--- a/src/uglify-es-benchmark.test.js
+++ b/src/uglify-es-benchmark.test.js
@@ -1,7 +1,0 @@
-// Copyright 2017 the V8 project authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
-const uglifyEsBenchmark = require("./uglify-es-benchmark");
-
-it("uglify-es-benchmark runs to completion", () => void uglifyEsBenchmark.fn());


### PR DESCRIPTION
`uglify-es` is no longer maintained. `terser` is a fork of `uglify-es`
that retains API and CLI compatibility with `uglify-es` and
`uglify-js@3`.
Update the docs, update the README with the output of a run that
includes the new `terser` benchmark and update the `package-lock.json`.
Resolves #59